### PR TITLE
Update to pcap2 library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,29 @@
 {
-    "name"         : "node-red-contrib-pcap",
-    "version"      : "1.0.1",
-    "description"  : "Network packet capture for Node-RED",
-    "homepage"     : "http://github.com/njh/node-red-contrib-pcap",
-    "license"      : "Apache-2.0",
-    "repository"   : {
-        "type": "git",
-        "url": "https://github.com/njh/node-red-contrib-pcap.git"
-    },
-    "author": {
-        "name": "Nicholas Humfrey", "url": "http://njh.me/"
-    },
-    "keywords": [
-        "pcap", "Packet Capture", "ARP", "node-red"
-    ],
-    "dependencies": {
-        "pcap": "2.0.1"
-    },
-    "node-red": {
-        "nodes": {
-            "pcap": "pcap.js"
-        }
+  "name": "node-red-contrib-pcap",
+  "version": "1.0.1",
+  "description": "Network packet capture for Node-RED",
+  "homepage": "http://github.com/njh/node-red-contrib-pcap",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/njh/node-red-contrib-pcap.git"
+  },
+  "author": {
+    "name": "Nicholas Humfrey",
+    "url": "http://njh.me/"
+  },
+  "keywords": [
+    "pcap",
+    "Packet Capture",
+    "ARP",
+    "node-red"
+  ],
+  "dependencies": {
+    "pcap2": "^3.0.4"
+  },
+  "node-red": {
+    "nodes": {
+      "pcap": "pcap.js"
     }
+  }
 }

--- a/pcap.js
+++ b/pcap.js
@@ -17,7 +17,7 @@
 module.exports = function(RED) {
     "use strict";
     var os = require('os');
-    var pcap = require('pcap');
+    var pcap = require('pcap2');
 
     function PacketCapture(n) {
         RED.nodes.createNode(this, n);


### PR DESCRIPTION
Hi,

It looks like the `pcap` node does not install in newer versions of nodejs (6.x), and is not updated in a while. Changing to `pcap2` seems to work, and seems to have a compatible api (it is a fork of the former). What about using the newer one?

P.S.: Still need to bump the package's version number